### PR TITLE
Support Global Invalidations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,16 @@ no external dependencies apart from the AWS CLI. So long as `aws` is on your `PA
 
 ## Usage
 
+### Simple Synchronization
+
 Sync the local `_site` directory to the
 `mybucket` S3 bucket under `/blog/`, generating an invalidation for the given CloudFront distribution:
 
 ```
 s3cf-deploy -c A3KNEPBLWRNDQ _site mybucket /blog/
 ```
+
+### Advanced Synchronization
 
 Same as before, but now pass custom arguments to `aws s3 sync` using the `S3_OPTS` environment variable:
 
@@ -24,3 +28,15 @@ S3_OPTS="--delete --sse AES256" s3cf-deploy -c $CF_DIST_ID public/ mybucket
 > **NOTE**: `shlex.split` is used to break apart arguments defined in `S3_OPTS`.
 
 As noted in the program help output, the default remote path to sync to is `/`, the root of the bucket.
+
+### Global Invalidations
+
+Global invalidations are possible with CloudFront in order to avoid charges for individual invalidations. CloudFront
+[starts charging for invalidations](https://aws.amazon.com/cloudfront/pricing/) after the first 1,000 path invalidations
+requested in a month, so if you're invalidating a lot of paths consistently, it can get expensive to invalidate specific
+paths as opposed to using a wildcard invalidation, which counts only as a single path. Global invalidations can be
+enabled with the `-a` flag:
+
+```
+s3cf-deploy -a -c A3KNEPBLWRNDQ _site mybucket /blog/
+```

--- a/s3cf-deploy
+++ b/s3cf-deploy
@@ -50,13 +50,14 @@ class InvalidationResult(object):
 
 class S3CFDeploy(object):
 
-    def __init__(self, logger, path, bucket, remote_path, cloudfront_dist_id, sync_opts):
+    def __init__(self, logger, path, bucket, remote_path, cloudfront_dist_id, sync_opts, invalidate_all):
         self.logger = logger
         self.path = path
         self.bucket = bucket
         self.remote_path = remote_path
         self.cloudfront_dist_id = cloudfront_dist_id
         self.sync_opts = sync_opts
+        self.invalidate_all = invalidate_all
 
     def sync(self):
         """Runs the S3 sync and returns a list of filenames to invalidate."""
@@ -102,8 +103,14 @@ class S3CFDeploy(object):
         else:
             self.logger.debug("CloudFront support is already enabled.")
 
-        cmd_args = ["aws", "cloudfront", "create-invalidation", "--distribution-id", self.cloudfront_dist_id,
-            "--paths"] + list(map(lambda c: c.remote_path, changed_files))
+        if self.invalidate_all:
+            # if we're doing global invalidations, just invalidate '*'
+            cmd_args = ["aws", "cloudfront", "create-invalidation", "--distribution-id", self.cloudfront_dist_id,
+                "--paths", "/*"]
+        else:
+            # if we're not doing a global invalidation, invalidate only the changed paths
+            cmd_args = ["aws", "cloudfront", "create-invalidation", "--distribution-id", self.cloudfront_dist_id,
+                "--paths"] + list(map(lambda c: c.remote_path, changed_files))
 
         self.logger.info("Running CloudFront invalidation command: %s", " ".join(cmd_args))
 
@@ -174,6 +181,8 @@ def main():
     parser.add_argument('-d', '--debug', action='store_true', default=False,
         help="Debug logging. This implies --verbose.")
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help="Verbose logging.")
+    parser.add_argument("-a", "--invalidate-all", action="store_true", default=False,
+        help="Submit an invalidation for all paths (*) as opposed to individual paths.")
     parser.add_argument("-c", "--cloudfront-distro", help="CloudFront distribution ID to create invalidations for.",
         required=True)
 
@@ -190,7 +199,7 @@ def main():
 
     # create worker
     deployer = S3CFDeploy(logger=logger, path=args.path, bucket=args.bucket, remote_path=args.remote_path,
-        cloudfront_dist_id=args.cloudfront_distro, sync_opts=shlex.split(s3_opts))
+        cloudfront_dist_id=args.cloudfront_distro, sync_opts=shlex.split(s3_opts), invalidate_all=args.invalidate_all)
 
     try:
         sync_results, invalidation = deployer.deploy()


### PR DESCRIPTION
This is due to the CloudFront invalidation API being expensive and the `aws s3 sync` command being sucky.